### PR TITLE
Updated lambda node version to 8.10. Removed default region

### DIFF
--- a/schematics/serverless/src/files/aws/serverless-aws.yml
+++ b/schematics/serverless/src/files/aws/serverless-aws.yml
@@ -6,11 +6,10 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
   memorySize: 192
   timeout: 10
   stage: production
-  region: eu-central-1
 
 package:
   exclude:


### PR DESCRIPTION
Submit an improvement over the current serverless setup. Nodejs 8.10 is currently supported in serverless