### PR TITLE
Fixed webpack-cli dependency typo

### DIFF
--- a/schematics/serverless/src/index.ts
+++ b/schematics/serverless/src/index.ts
@@ -95,7 +95,7 @@ export default function addServerless(options: any): Rule {
         });
         addPackageJsonDependency(tree, {
             type: NodeDependencyType.Dev,
-            name: 'webpack-cl',
+            name: 'webpack-cli',
             version: '2.1.2'
         });
         addPackageJsonDependency(tree, {


### PR DESCRIPTION
There was a typo that meant "webpack-cl" was being added to the package.json instead of "webpack-cli" which would result in an error when npm attempted to install the package.

Related to issue https://github.com/maciejtreder/ng-toolkit/issues/596