### PR TITLE
Update fs to fs-extra and fixed an iteration when there are no 'imports'

### DIFF
--- a/schematics/universal/src/files/prerender.ts
+++ b/schematics/universal/src/files/prerender.ts
@@ -1,5 +1,5 @@
 const domino = require('domino');
-const fs = require('fs');
+const fs = require('fs-extra');
 const template = fs.readFileSync('./dist/browser/index.html').toString();
 const win = domino.createWindow(template);
 const filesBrowser = fs.readdirSync(`${process.cwd()}/dist/browser`)
@@ -158,7 +158,7 @@ allRoutes.forEach((route) => {
 // copy static files
 filesBrowser.forEach(file => {
     if (file !== 'index.html') {
-        fs.copyFileSync(`./dist/browser/${file}`, `./dist/static/${file}`);
+        fs.copySync(`./dist/browser/${file}`, `./dist/static/${file}`);
     }
 });
 


### PR DESCRIPTION
1- **Update 'fs' to 'fs-extra'** 
When: 
`const filesBrowser = fs.readdirSync(`${process.cwd()}/dist/browser`)`

The const take all files and folders, but then during copy: 
`fs.copyFileSync(`./dist/browser/${file}`, `./dist/static/${file}`);`

Apparently only support files, not folders. So added 'fs-extra' instead of 'fs'.

2- **Iteration when there are no 'imports'** 
When:
`const importsNode = node.properties.find(node => {
                  return (<ts.Identifier> node.name).escapedText === 'imports';
                });`

Sometimes there are no 'imports' so added an 'if (true)'.

