### PR TITLE
[Bugfix] Travis missing init package for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vscode/
 *.iml
 dist/
+verdacio_output
+scripts/storage/*

--- a/schematics/_utils/package.json
+++ b/schematics/_utils/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Maciej Treder <contact@maciejtreder.com>",
   "name": "@ng-toolkit/_utils",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Angular Universal PWA boilerplate for serverless environment.",
   "repository": {
     "type": "git",

--- a/schematics/firebug/package.json
+++ b/schematics/firebug/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Maciej Treder <contact@maciejtreder.com>",
   "name": "@ng-toolkit/firebug",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Add Firebug lite to your Angular project.",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "@angular-devkit/core": "^8.3.3",
     "@angular-devkit/schematics": "^8.3.3",
     "@bugsnag/js": "^6.4.0",
-    "@ng-toolkit/_utils": "8.0.2",
+    "@ng-toolkit/_utils": "8.0.3",
     "@schematics/angular": "^8.3.3"
   },
   "devDependencies": {

--- a/schematics/init/package.json
+++ b/schematics/init/package.json
@@ -11,7 +11,7 @@
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && jasmine src/**/*_spec.js",
     "postinstall": "node postinstall.js",
-    "prepublish": "npm test",
+    "prepare": "npm test",
     "ci-publish": "ci-publish"
   },
   "keywords": [

--- a/schematics/init/package.json
+++ b/schematics/init/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Maciej Treder <contact@maciejtreder.com>",
   "name": "@ng-toolkit/init",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Angular Universal PWA boilerplate for serverless environment.",
   "repository": {
     "type": "git",
@@ -32,9 +32,9 @@
     "@angular-devkit/core": "^8.3.3",
     "@angular-devkit/schematics": "^8.3.3",
     "@bugsnag/js": "^6.4.0",
-    "@ng-toolkit/_utils": "8.0.2",
-    "@ng-toolkit/firebug": "8.0.2",
-    "@ng-toolkit/serverless": "8.0.2",
+    "@ng-toolkit/_utils": "8.0.3",
+    "@ng-toolkit/firebug": "8.0.3",
+    "@ng-toolkit/serverless": "8.0.3",
     "@schematics/angular": "^8.3.3"
   },
   "devDependencies": {

--- a/schematics/pwa/package.json
+++ b/schematics/pwa/package.json
@@ -2,7 +2,7 @@
   "author": "Maciej Treder <contact@maciejtreder.com>",
   "name": "@ng-toolkit/pwa",
   "main": "dist/index.js",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Extension for @angular/pwa - adds server-side rendering fixes and update mechanism",
   "repository": {
     "type": "git",
@@ -37,10 +37,10 @@
   },
   "dependencies": {
     "@bugsnag/js": "^6.4.0",
-    "@ng-toolkit/_utils": "8.0.2"
+    "@ng-toolkit/_utils": "8.0.3"
   },
   "devDependencies": {
-    "@ng-toolkit/universal": "^8.0.1",
+    "@ng-toolkit/universal": "^8.0.3",
     "@angular-devkit/build-angular": "^0.803.4",
     "@angular-devkit/build-ng-packagr": "^0.803.4",
     "@angular-devkit/core": "^8.3.3",

--- a/schematics/pwa/publish.sh
+++ b/schematics/pwa/publish.sh
@@ -1,1 +1,4 @@
-npm run ci-publish
+# Move to generated production folder
+cd dist
+# Run package ci-publish script
+./../node_modules/ci-publish/bin/ci-publish.js 

--- a/schematics/pwa/publish_verdaccio.sh
+++ b/schematics/pwa/publish_verdaccio.sh
@@ -1,1 +1,4 @@
+# Move to generated production folder
+cd dist
+# Run publish script
 npm publish --registry http://localhost:4873

--- a/schematics/serverless/package.json
+++ b/schematics/serverless/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Maciej Treder <contact@maciejtreder.com>",
   "name": "@ng-toolkit/serverless",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Angular Universal PWA boilerplate for serverless environment.",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "@angular-devkit/core": "^8.3.3",
     "@angular-devkit/schematics": "^8.3.3",
     "@bugsnag/js": "^6.4.0",
-    "@ng-toolkit/_utils": "8.0.2",
+    "@ng-toolkit/_utils": "8.0.3",
     "@schematics/angular": "^8.3.3"
   },
   "devDependencies": {

--- a/schematics/universal/package.json
+++ b/schematics/universal/package.json
@@ -2,7 +2,7 @@
   "author": "Maciej Treder <contact@maciejtreder.com>",
   "name": "@ng-toolkit/universal",
   "main": "dist/index.js",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Adds Angular Universal support for any Angular CLI project",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "@angular-devkit/core": "^8.3.3",
     "@angular-devkit/schematics": "^8.3.3",
     "@bugsnag/js": "^6.4.0",
-    "@ng-toolkit/_utils": "8.0.2",
+    "@ng-toolkit/_utils": "8.0.3",
     "@nguniversal/express-engine": "^8.1.1",
     "@schematics/angular": "^8.3.3"
   },
@@ -50,8 +50,8 @@
     "@angular/compiler": "^8.2.6",
     "@angular/compiler-cli": "^8.2.6",
     "@angular/core": "^8.2.6",
-    "@ng-toolkit/pwa": "8.0.2",
-    "@ng-toolkit/serverless": "8.0.2",
+    "@ng-toolkit/pwa": "8.0.3",
+    "@ng-toolkit/serverless": "8.0.3",
     "@types/jasmine": "^3.4.0",
     "@types/node": "^12.7.4",
     "ci-publish": "^1.3.1",

--- a/schematics/universal/publish.sh
+++ b/schematics/universal/publish.sh
@@ -1,1 +1,4 @@
-npm run ci-publish
+# Move to generated production folder
+cd dist
+# Run package ci-publish script
+./../node_modules/ci-publish/bin/ci-publish.js 

--- a/schematics/universal/publish_verdaccio.sh
+++ b/schematics/universal/publish_verdaccio.sh
@@ -1,1 +1,4 @@
+# Move to generated production folder
+cd dist
+# Run publish script
 npm publish --registry http://localhost:4873

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,7 @@ npm install -g @angular/cli
 
 cd schematics
 
-CATALOGS=(_utils serverless universal pwa firebug)
+CATALOGS=(_utils serverless universal pwa firebug init)
 
 exitStatus=0
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,8 +1,7 @@
-npm install -g @angular/cli
-
-cd schematics
-
 CATALOGS=(_utils serverless universal pwa firebug init)
+
+npm install -g @angular/cli
+cd schematics
 
 exitStatus=0
 

--- a/scripts/deploy_verdaccio.sh
+++ b/scripts/deploy_verdaccio.sh
@@ -1,4 +1,4 @@
-CATALOGS=(_utils serverless pwa universal firebug init)
+CATALOGS=(_utils serverless universal pwa firebug init)
 echo "//localhost:4873/:_authToken=\"CjmKyL6UDkX6FDpNnP64fw==\"" >>~/.npmrc
 
 npm install -g @angular/cli
@@ -23,9 +23,6 @@ for i in "${CATALOGS[@]}"; do
     cd $i
     npm install --verbose
     printf '\e[1;32m--- NPM INSTALL COMPLETED FOR %s ---\e[0m\n' "$i"
-    if [ "$i" != "_utils" ]; then
-        ls node_modules/@ng-toolkit/_utils
-    fi
     if ./publish_verdaccio.sh; then
         printf '\e[1;33m*** %s PASSED ***\e[0m\n' "$i"
     else

--- a/scripts/deploy_verdaccio.sh
+++ b/scripts/deploy_verdaccio.sh
@@ -1,4 +1,4 @@
-CATALOGS=(_utils serverless pwa universal firebug)
+CATALOGS=(_utils serverless pwa universal firebug init)
 echo "//localhost:4873/:_authToken=\"CjmKyL6UDkX6FDpNnP64fw==\"" >>~/.npmrc
 
 npm install -g @angular/cli


### PR DESCRIPTION
Add `@ng-toolkit/init` package to the deployment scripts and also ignore generated files on local test.

Fixes:
- #712
- #716

Also, I noticed I messed up on my last PR for the PWA and Universal packages, as the dist folder has to be used for running `ci-publish`. This should fix #466 too!