### PR TITLE
Downgrade universal package in pwa to fix travis build

### DIFF
--- a/schematics/pwa/package.json
+++ b/schematics/pwa/package.json
@@ -40,7 +40,7 @@
     "@ng-toolkit/_utils": "8.0.3"
   },
   "devDependencies": {
-    "@ng-toolkit/universal": "^8.0.3",
+    "@ng-toolkit/universal": "^8.0.1",
     "@angular-devkit/build-angular": "^0.803.4",
     "@angular-devkit/build-ng-packagr": "^0.803.4",
     "@angular-devkit/core": "^8.3.3",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,4 @@
-CATALOGS=(_utils serverless universal pwa firebug init)
+CATALOGS=(_utils serverless pwa universal firebug init)
 
 npm install -g @angular/cli
 cd schematics

--- a/scripts/deploy_verdaccio.sh
+++ b/scripts/deploy_verdaccio.sh
@@ -1,4 +1,4 @@
-CATALOGS=(_utils serverless universal pwa firebug init)
+CATALOGS=(_utils serverless pwa universal firebug init)
 echo "//localhost:4873/:_authToken=\"CjmKyL6UDkX6FDpNnP64fw==\"" >>~/.npmrc
 
 npm install -g @angular/cli


### PR DESCRIPTION
`PWA` always have to come first and load an older version of the `universal`.

We should refactor some code to avoid this kind of dependency between those two packages.